### PR TITLE
Fixes issue28.

### DIFF
--- a/src/SampleService/CompositeType.cs
+++ b/src/SampleService/CompositeType.cs
@@ -53,6 +53,9 @@ namespace SampleService
 
 		[DataMember]
 		public EnumType? EnumValue { get; set; }
+
+		[DataMember]
+		public short ShortValue { get; set; }
 	}
 
 	public enum EnumType

--- a/src/SampleService/IRESTful.cs
+++ b/src/SampleService/IRESTful.cs
@@ -42,21 +42,36 @@ namespace SampleService
 		[ResponseCode(401, "Something weird happened")]
 		[ResponseCode(301, "Three O one Something weird happened")]
 		[OperationContract]
-		[WebInvoke(UriTemplate = "/data", Method = "POST", RequestFormat = WebMessageFormat.Json, BodyStyle = WebMessageBodyStyle.Bare)]
+		[WebInvoke(UriTemplate = "/data", Method = "POST", RequestFormat = WebMessageFormat.Json,
+			BodyStyle = WebMessageBodyStyle.Bare)]
 		CompositeType GetDataUsingDataContract(CompositeType composite);
 
 		[OperationContract]
 		[WebInvoke(
-			 UriTemplate = "/Data/{value}?val={anothervalue}&option={optionalvalue}",
-			 Method = "PUT", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json, BodyStyle = WebMessageBodyStyle.Bare)]
-		string PutData(string value, [ParameterSettings(IsRequired = true, Description = "Yes, you need to include this.")]string anothervalue,
-			 [ParameterSettings(UnderlyingType = typeof(int))]string optionalvalue);
+			UriTemplate = "/Data/{value}?val={anothervalue}&option={optionalvalue}",
+			Method = "PUT", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json,
+			BodyStyle = WebMessageBodyStyle.Bare)]
+		string PutData(string value,
+			[ParameterSettings(IsRequired = true, Description = "Yes, you need to include this.")] string anothervalue,
+			[ParameterSettings(UnderlyingType = typeof (int))] string optionalvalue);
 
 		[OperationContract]
 		[Swaggerator.Attributes.Produces(ContentType = "application/xml")]
 		[Swaggerator.Attributes.Produces(ContentType = "application/customformat")]
 		[WebGet(UriTemplate = "/List")]
 		CompositeType[] GetList();
+
+		[OperationContract]
+		[WebInvoke(UriTemplate = "/Data/{value}",
+			Method = "DELETE", RequestFormat = WebMessageFormat.Json, ResponseFormat = WebMessageFormat.Json,
+			BodyStyle = WebMessageBodyStyle.Bare)]
+		void Delete(string value);
+
+		[OperationContract]
+		[WebGet(UriTemplate = "/Data2/{value}")]
+		[OperationSummary("Example for hiding a parameter")]
+		[OperationNotes("The second parameter, object 'bar' is hidden")]
+		int HideOneOfTwoParams(int foo, [ParameterSettings(Hidden = true)]object bar);
 	}
 
 

--- a/src/SampleService/RESTful.svc.cs
+++ b/src/SampleService/RESTful.svc.cs
@@ -17,6 +17,7 @@
  * RESTful.svc.cs : Sample service implementation
  */
 
+using System.Web.Services.Description;
 using Swaggerator.Attributes;
 using System;
 using System.Collections.Generic;
@@ -72,5 +73,15 @@ namespace SampleService
 				new CompositeType { Secret=new SecretObject { SecretData="WHAT?!" } }
 			};
         }
+
+	    public void Delete(string value)
+	    {
+		    
+	    }
+
+	    public int HideOneOfTwoParams(int foo, object bar)
+	    {
+		    return foo;
+	    }
     }
 }

--- a/src/Swaggerator.Test/MapperTests.cs
+++ b/src/Swaggerator.Test/MapperTests.cs
@@ -24,6 +24,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Linq;
 using Swaggerator.Attributes;
+using Swaggerator.Models;
 
 namespace Swaggerator.Test
 {
@@ -48,7 +49,7 @@ namespace Swaggerator.Test
 			var map = typeof(MapTest).GetInterfaceMap(typeof(IMapTest));
 			var operations = mapper.GetOperations(map, new Stack<Type>());
 
-			Assert.AreEqual(1, operations.Count());
+			Assert.AreEqual(3, operations.Count());
 			Assert.AreEqual("/method/test", operations.First().Item1);
 			var operation = operations.First().Item2;
 
@@ -64,7 +65,7 @@ namespace Swaggerator.Test
 
 			Assert.AreEqual("query", dos.paramType);
 			Assert.AreEqual(false, dos.required);
-			Assert.AreEqual("integer", dos.type);
+			Assert.AreEqual("integer(32)", dos.type);
 
 			Assert.AreEqual("query", tres.paramType);
 			Assert.AreEqual(false, tres.required);
@@ -138,6 +139,60 @@ namespace Swaggerator.Test
 			Assert.AreEqual("Short format", operation.summary);
 			Assert.AreEqual("Long format", operation.notes);
 		}
+		
+		[TestMethod]
+		public void CanMapVoidOperation()
+		{
+			var mapper = new Mapper(null);
+			var map = typeof (MapTest).GetInterfaceMap(typeof (IMapTest));
+			var operations = mapper.GetOperations(map, new Stack<Type>());
+			var operation = operations.First(o => o.Item1.Equals("/voidtest")).Item2;
+			Assert.IsNotNull(operation);
+			Assert.AreEqual("None",operation.type);
+		}
+
+		[TestMethod]
+		public void CanMapBuiltInParams()
+		{
+			var mapper = new Mapper(null);
+			var map = typeof(MapTest).GetInterfaceMap(typeof(IMapTest));
+			var operations = mapper.GetOperations(map, new Stack<Type>());
+			var operation = operations.First(o => o.Item1.Equals("/voidtest")).Item2;
+
+			Assert.AreEqual(15, operation.parameters.Count);
+			Assert.AreEqual("boolean", GetTypeFromParamList("bl", operation.parameters));
+			Assert.AreEqual("integer(8)", GetTypeFromParamList("bt", operation.parameters));
+			Assert.AreEqual("integer(8, signed)", GetTypeFromParamList("sbt", operation.parameters));
+			Assert.AreEqual("character", GetTypeFromParamList("ch", operation.parameters));
+			Assert.AreEqual("decimal", GetTypeFromParamList("dm", operation.parameters));
+			Assert.AreEqual("double", GetTypeFromParamList("db", operation.parameters));
+			Assert.AreEqual("float", GetTypeFromParamList("fl", operation.parameters));
+			Assert.AreEqual("integer(32)", GetTypeFromParamList("it", operation.parameters));
+			Assert.AreEqual("integer(32, unsigned)", GetTypeFromParamList("uit", operation.parameters));
+			Assert.AreEqual("integer(64)", GetTypeFromParamList("lg", operation.parameters));
+			Assert.AreEqual("integer(64, unsigned)", GetTypeFromParamList("ulg", operation.parameters));
+			Assert.AreEqual("integer(16)", GetTypeFromParamList("st", operation.parameters));
+			Assert.AreEqual("integer(16, unsigned)", GetTypeFromParamList("ust", operation.parameters));
+			Assert.AreEqual("string", GetTypeFromParamList("str", operation.parameters));
+			Assert.AreEqual("Date", GetTypeFromParamList("dt", operation.parameters));
+		}
+
+		[TestMethod]
+		public void CanHideParameter()
+		{
+			var mapper = new Mapper(null);
+			var map = typeof(MapTest).GetInterfaceMap(typeof(IMapTest));
+			var operations = mapper.GetOperations(map, new Stack<Type>());
+			var operation = operations.First(o => o.Item1.Equals("/hideparamtest")).Item2;
+			Assert.AreEqual(1, operation.parameters.Count);
+			Assert.AreEqual("foo", operation.parameters[0].name);
+			Assert.AreEqual("integer(32)", operation.parameters[0].type);
+		}
+
+		private string GetTypeFromParamList(string name, List<Parameter> parameters)
+		{
+			return (parameters.First(p => p.name.Equals(name))).type;
+		}
 
 		interface IMapTest
 		{
@@ -159,6 +214,27 @@ namespace Swaggerator.Test
 			[Produces(ContentType = "application/xml")]
 			[WebGet(UriTemplate = "/keepitsecret")]
 			int SecretMethod();
+
+			[WebInvoke(Method = "DELETE", UriTemplate = "/voidtest")]
+			void VoidMethod(
+				bool bl, 
+				byte bt, 
+				sbyte sbt, 
+				char ch, 
+				decimal dm,
+				double db,
+				float fl,
+				int it,
+				uint uit,
+				long lg,
+				ulong ulg,
+				short st,
+				ushort ust,
+				string str,
+				DateTime dt);
+
+			[WebGet(UriTemplate = "/hideparamtest")]
+			int HideParamTest(int foo, [ParameterSettings(Hidden = true)]string bar);
 		}
 
 		class MapTest : IMapTest
@@ -166,6 +242,28 @@ namespace Swaggerator.Test
 			public int Method(string uno, [ParameterSettings(IsRequired = false, UnderlyingType = typeof(int))]string dos, string tres) { throw new NotImplementedException(); }
 
 			public int SecretMethod() { throw new NotImplementedException(); }
+
+			public void VoidMethod(
+				bool bl,
+				byte bt,
+				sbyte sbt,
+				char ch,
+				decimal dm,
+				double db,
+				float fl,
+				int it,
+				uint uit,
+				long lg,
+				ulong ulg,
+				short st,
+				ushort ust,
+				string str,
+				DateTime dt)
+			{
+				throw new NotImplementedException();
+			}
+
+			public int HideParamTest(int foo, string bar) { throw new NotImplementedException();}
 		}
 	}
 }

--- a/src/Swaggerator.Test/SerializerTests.cs
+++ b/src/Swaggerator.Test/SerializerTests.cs
@@ -48,12 +48,13 @@ namespace Swaggerator.Test
 			var props = obj["properties"] as JObject;
 			Assert.IsNotNull(props);
 			Assert.IsTrue(props.HasValues);
-			Assert.AreEqual(4, props.Count);
+			Assert.AreEqual(5, props.Count);
 
 			Assert.AreEqual(true, props["BoolValue"]["required"]);
 			Assert.AreEqual("array", props["ArrayValue"]["type"]);
 			Assert.AreEqual("string", props["EnumValue"]["type"]);
 			Assert.AreEqual(false, props["EnumValue"]["required"]);
+			Assert.AreEqual("integer(16)", props["ShortValue"]["type"]);
 		}
 
 		[TestMethod]

--- a/src/Swaggerator/Attributes/ParameterSettingsAttribute.cs
+++ b/src/Swaggerator/Attributes/ParameterSettingsAttribute.cs
@@ -30,15 +30,18 @@ namespace Swaggerator.Attributes
 		/// <param name="isRequired">Is the parameter required or optional for this method. Defaults to false (not required).</param>
 		/// <param name="underlyingType">What is the expected type for the parameter (int, bool, string, etc.)</param>
 		/// <param name="description">Descriptive text.</param>
-		public ParameterSettingsAttribute(bool isRequired = false, Type underlyingType = null, string description = null)
+		/// <param name="hidden">Should be parameter be hidden for this method? Defaults to false.</param>
+		public ParameterSettingsAttribute(bool isRequired = false, Type underlyingType = null, string description = null, bool hidden = false)
 		{
 			IsRequired = isRequired;
 			UnderlyingType = underlyingType;
 			Description = description;
+			Hidden = hidden;
 		}
 
 		public bool IsRequired { get; set; }
 		public Type UnderlyingType { get; set; }
 		public string Description { get; set; }
+		public bool Hidden { get; set; }
 	}
 }

--- a/src/Swaggerator/Helpers.cs
+++ b/src/Swaggerator/Helpers.cs
@@ -33,14 +33,24 @@ namespace Swaggerator
 
 		public static string MapSwaggerType(Type type, Stack<Type> typeMap)
 		{
-			if (type == typeof(byte)) { return "byte"; }
+			//built-in types
 			if (type == typeof(bool)) { return "boolean"; }
-			if (type == typeof(int)) { return "integer"; }
-			if (type == typeof(long)) { return "long"; }
-			if (type == typeof(float)) { return "float"; }
+			if (type == typeof(byte)) { return "integer(8)"; }
+			if (type == typeof (sbyte)) { return "integer(8, signed)";}
+			if (type == typeof (char)) { return "character"; }
+			if (type == typeof(decimal)) { return "decimal"; }
 			if (type == typeof(double)) { return "double"; }
+			if (type == typeof(float)) { return "float"; }
+			if (type == typeof(int)) { return "integer(32)"; }
+			if (type == typeof(uint)) { return "integer(32, unsigned)"; }
+			if (type == typeof(long)) { return "integer(64)"; }
+			if (type == typeof(ulong)) { return "integer(64, unsigned)"; }
+			if (type == typeof(short)) { return "integer(16)"; }
+			if (type == typeof(ushort)) { return "integer(16, unsigned)"; }
 			if (type == typeof(string)) { return "string"; }
 			if (type == typeof(DateTime)) { return "Date"; }
+
+			if (type == typeof (void)) {return "None";}
 
 			//it's an enum, use string as the property type and enum values will be serialized later
 			if (type.IsEnum) { return "string"; }

--- a/src/Swaggerator/Mapper.cs
+++ b/src/Swaggerator/Mapper.cs
@@ -188,6 +188,9 @@ namespace Swaggerator
 						 parameter.GetCustomAttribute<Attributes.ParameterSettingsAttribute>();
 					if (settings != null)
 					{
+						if (settings.Hidden)
+							continue;
+
 						parm.required = settings.IsRequired;
 						parm.description = settings.Description ?? parm.description;
 						parm.type = settings.UnderlyingType == null ? parm.type :


### PR DESCRIPTION
Fix for #28 . All of the C# built-in types are mapped, except object. Added ability to hide a parameter. It is useful for hiding unnecessary parameters in an asynch operation. #28 relates to #32 .

See the page below for all built-in types. 

http://msdn.microsoft.com/en-us/library/ya5y69ds.aspx
