### PR TITLE
Fix for issue 39. Renamed attribute setting MaxLength to TypeSizeNote.

### DIFF
--- a/src/SampleService/CompositeType.cs
+++ b/src/SampleService/CompositeType.cs
@@ -58,7 +58,7 @@ namespace SampleService
 		public short ShortValue { get; set; }
 
 		[DataMember]
-		[MemberProperties(MaxLength = "10", Description = "Description text")]
+		[MemberProperties(TypeSizeNote = "10", Description = "Description text")]
 		public string StringValueWithLengthRestriction { get; set; }
 	}
 

--- a/src/SampleService/IRESTful.cs
+++ b/src/SampleService/IRESTful.cs
@@ -52,7 +52,7 @@ namespace SampleService
 		string PutData(string value,
 			[ParameterSettings(IsRequired = true, Description = "Yes, you need to include this.")] string anothervalue,
 			[ParameterSettings(UnderlyingType = typeof (int))] string optionalvalue, 
-			[ParameterSettings(MaxLength = "123")] string valueWithLengthRequirement);
+			[ParameterSettings(TypeSizeNote = "123")] string valueWithLengthRequirement);
 
 		[OperationContract]
 		[Swaggerator.Attributes.Produces(ContentType = "application/xml")]

--- a/src/Swaggerator.Test/MapperTests.cs
+++ b/src/Swaggerator.Test/MapperTests.cs
@@ -203,7 +203,7 @@ namespace Swaggerator.Test
 			int Method(
 				[ParameterSettings(IsRequired = true)]string uno,
 				[ParameterSettings(IsRequired = true)]string dos,
-				[ParameterSettings(Description = "The third option.", MaxLength = "22")]string thRee);
+				[ParameterSettings(Description = "The third option.", TypeSizeNote = "22")]string thRee);
 
 			[Tag("SecretThings")]
 			[ResponseCode(500, "Just because.")]

--- a/src/Swaggerator.Test/SerializerTests.cs
+++ b/src/Swaggerator.Test/SerializerTests.cs
@@ -163,6 +163,14 @@ namespace Swaggerator.Test
 			Assert.IsNotNull(container);
 			Assert.AreEqual("string(10)", container["type"]);
 			Assert.AreEqual("my string description", container["description"]);
+
+			var anotherSerializer = new Serializer(null);
+			var sampleBModelSerialized = anotherSerializer.WriteType(typeof (ModelSampleC), new Stack<Type>());
+			Assert.IsFalse(string.IsNullOrEmpty(sampleBModelSerialized));
+			var sbObj = JObject.Parse(sampleBModelSerialized);
+			var sbContainer = sbObj["properties"]["MyString2"];
+			Assert.IsNotNull(sbContainer);
+			Assert.AreEqual("string", sbContainer["type"]);
 		}
 
 
@@ -172,13 +180,20 @@ namespace Swaggerator.Test
 		internal class ModelSampleA
 		{
 			[DataMember]
-			[MemberProperties(MaxLength = "10", Description = "my string description")]
+			[MemberProperties(TypeSizeNote = "10", Description = "my string description")]
 			public string MyString { get; set; }
 		}
 
 		internal class ModelSampleB
 		{
 			public string MyString { get; set; }
+		}
+
+		[DataContract]
+		internal class ModelSampleC
+		{
+			[DataMember]
+			public string MyString2 { get; set; }
 		}
 
 	}

--- a/src/Swaggerator/Attributes/MemberPropertiesAttribute.cs
+++ b/src/Swaggerator/Attributes/MemberPropertiesAttribute.cs
@@ -25,13 +25,18 @@ namespace Swaggerator.Attributes
 	[AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
 	public class MemberPropertiesAttribute : Attribute
 	{
-		public MemberPropertiesAttribute(string maxLength = null, string description = null)
+		/// <summary>
+		/// Attribute used to specify properties of a DataMeber
+		/// </summary>
+		/// <param name="typeSizeNote">Summary for data type size/range, usally in numbers.</param>
+		/// <param name="description">Description for a DataMember</param>
+		public MemberPropertiesAttribute(string typeSizeNote = null, string description = null)
 		{
-			MaxLength = maxLength;
+			TypeSizeNote = typeSizeNote;
 			Description = description;
 		}
 
-		public string MaxLength { get; set; }
+		public string TypeSizeNote { get; set; }
 
 		public string Description { get; set; }
 	}

--- a/src/Swaggerator/Attributes/ParameterSettingsAttribute.cs
+++ b/src/Swaggerator/Attributes/ParameterSettingsAttribute.cs
@@ -31,20 +31,20 @@ namespace Swaggerator.Attributes
 		/// <param name="underlyingType">What is the expected type for the parameter (int, bool, string, etc.)</param>
 		/// <param name="description">Descriptive text.</param>
 		/// <param name="hidden">Should be parameter be hidden for this method? Defaults to false.</param>
-		/// <param name="maxLength">What is the maximum allowed length of parameter, if defined</param>
-		public ParameterSettingsAttribute(bool isRequired = false, Type underlyingType = null, string description = null, bool hidden = false, string maxLength = null)
+		/// <param name="typeSizeNote">Note about parameter data type, such as max length. It will appear as part of data type string.</param>
+		public ParameterSettingsAttribute(bool isRequired = false, Type underlyingType = null, string description = null, bool hidden = false, string typeSizeNote = null)
 		{
 			IsRequired = isRequired;
 			UnderlyingType = underlyingType;
 			Description = description;
 			Hidden = hidden;
-			MaxLength = maxLength;
+			TypeSizeNote = typeSizeNote;
 		}
 
 		public bool IsRequired { get; set; }
 		public Type UnderlyingType { get; set; }
 		public string Description { get; set; }
 		public bool Hidden { get; set; }
-		public string MaxLength { get; set; }
+		public string TypeSizeNote { get; set; }
 	}
 }

--- a/src/Swaggerator/Helpers.cs
+++ b/src/Swaggerator/Helpers.cs
@@ -31,24 +31,24 @@ namespace Swaggerator
 		private static readonly Regex _GenericTypeRegex = new Regex("^(.*)`.*");
 
 
-		public static string MapSwaggerType(Type type, Stack<Type> typeMap)
+		public static string MapSwaggerType(Type type, Stack<Type> typeMap, string typeNote = null)
 		{
 			//built-in types
-			if (type == typeof(bool)) { return "boolean"; }
-			if (type == typeof(byte)) { return "integer(8)"; }
-			if (type == typeof (sbyte)) { return "integer(8, signed)";}
-			if (type == typeof (char)) { return "character"; }
-			if (type == typeof(decimal)) { return "decimal"; }
-			if (type == typeof(double)) { return "double"; }
-			if (type == typeof(float)) { return "float"; }
-			if (type == typeof(int)) { return "integer(32)"; }
-			if (type == typeof(uint)) { return "integer(32, unsigned)"; }
-			if (type == typeof(long)) { return "integer(64)"; }
-			if (type == typeof(ulong)) { return "integer(64, unsigned)"; }
-			if (type == typeof(short)) { return "integer(16)"; }
-			if (type == typeof(ushort)) { return "integer(16, unsigned)"; }
-			if (type == typeof(string)) { return "string"; }
-			if (type == typeof(DateTime)) { return "Date"; }
+			if (type == typeof (bool)) {return BuildTypeString("boolean", typeNote);}
+			if (type == typeof(byte)) { return BuildTypeString("integer", "8", typeNote); }
+			if (type == typeof (sbyte)) { return BuildTypeString("integer", "8, signed", typeNote);}
+			if (type == typeof (char)) { return BuildTypeString("character", typeNote); }
+			if (type == typeof(decimal)) { return BuildTypeString("decimal", typeNote); }
+			if (type == typeof(double)) { return BuildTypeString("double", typeNote); }
+			if (type == typeof(float)) { return BuildTypeString("float", typeNote); }
+			if (type == typeof(int)) { return BuildTypeString("integer", "32", typeNote); }
+			if (type == typeof(uint)) { return BuildTypeString("integer", "32, unsigned", typeNote); }
+			if (type == typeof(long)) { return BuildTypeString("integer", "64", typeNote); }
+			if (type == typeof(ulong)) { return BuildTypeString("integer", "64, unsigned", typeNote); }
+			if (type == typeof(short)) { return BuildTypeString("integer", "16", typeNote); }
+			if (type == typeof(ushort)) { return BuildTypeString("integer", "16, unsigned", typeNote); }
+			if (type == typeof(string)) { return BuildTypeString("string", typeNote); }
+			if (type == typeof(DateTime)) { return BuildTypeString("Date", typeNote); }
 
 			if (type == typeof (void)) {return "None";}
 
@@ -64,6 +64,18 @@ namespace Swaggerator
 			//it's a complex type, so we'll need to map it later
 			if (!typeMap.Contains(type)) { typeMap.Push(type); }
 			return type.FullName;
+		}
+
+		private static string BuildTypeString(string typeName, string defaultNote = null, string typeNote = null)
+		{
+			const string resultFormat = "{0}({1})";
+				
+			if (string.IsNullOrEmpty(defaultNote) && string.IsNullOrEmpty(typeNote))
+				return typeName;
+
+			return string.IsNullOrEmpty(typeNote) 
+				? string.Format(resultFormat, typeName, defaultNote)
+				: string.Format(resultFormat, typeName, typeNote);
 		}
 		
 		public static T1 GetCustomAttributeValue<T1, T2>(MethodInfo method, string propertyName)

--- a/src/Swaggerator/Mapper.cs
+++ b/src/Swaggerator/Mapper.cs
@@ -193,9 +193,9 @@ namespace Swaggerator
 
 						parm.required = settings.IsRequired;
 						parm.description = settings.Description ?? parm.description;
-						parm.type = settings.UnderlyingType == null ? parm.type :
-							 Helpers.MapSwaggerType(settings.UnderlyingType, typeStack);
-						parm.type = settings.MaxLength == null ? parm.type : string.Format("{0}({1})", parm.type, settings.MaxLength);
+						parm.type = settings.UnderlyingType == null 
+							? HttpUtility.HtmlEncode(Helpers.MapSwaggerType(parameter.ParameterType, typeStack, settings.TypeSizeNote))
+							: HttpUtility.HtmlEncode(Helpers.MapSwaggerType(settings.UnderlyingType, typeStack, settings.TypeSizeNote));
 					}
 
 					operation.parameters.Add(parm);

--- a/src/Swaggerator/Serializer.cs
+++ b/src/Swaggerator/Serializer.cs
@@ -164,15 +164,9 @@ namespace Swaggerator
 				writer.WriteStartObject();
 
 				writer.WritePropertyName("type");
-				if (pType == typeof (string))
-				{
-					if(memberProperties != null && memberProperties.MaxLength != null)
-					writer.WriteValue(string.Format("{0}({1})", Helpers.MapSwaggerType(pType, typeStack), memberProperties.MaxLength));
-				}
-				else
-				{
-					writer.WriteValue(Helpers.MapSwaggerType(pType, typeStack));
-				}
+				writer.WriteValue(memberProperties != null
+					? Helpers.MapSwaggerType(pType, typeStack, memberProperties.TypeSizeNote)
+					: Helpers.MapSwaggerType(pType, typeStack));
 
 				writer.WritePropertyName("required");
 				writer.WriteValue(required);


### PR DESCRIPTION
Fixes issue39. Renamed attribute setting MaxLength to TypeSizeNote in MemberPropertiesAttribute and ParameterSettingsAttribute.
